### PR TITLE
$ cucumber throw "uninitialized constant FactoryBot (NameError)"

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -3,8 +3,6 @@ Coveralls.wear_merged!('rails')
 
 require 'cucumber/rails'
 
-World(FactoryBot::Syntax::Methods)
-
 ActionController::Base.allow_rescue = false
 
 begin


### PR DESCRIPTION
### User story
```
As a dev-team,
In order to use cucumber and not get an NameError for FactoryBot,
we would like to fix it by removing "World(FactoryBot::Syntax::Methods)" from env.rb
```