### PR TITLE
Assign roles to users

### DIFF
--- a/db/migrate/20180819144627_add_subscriber_to_users.rb
+++ b/db/migrate/20180819144627_add_subscriber_to_users.rb
@@ -1,0 +1,5 @@
+class AddSubscriberToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :subscriber, :boolean, default: false
+  end
+end

--- a/db/migrate/20180819144844_add_author_to_users.rb
+++ b/db/migrate/20180819144844_add_author_to_users.rb
@@ -1,0 +1,5 @@
+class AddAuthorToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :author, :boolean, default: false
+  end
+end

--- a/db/migrate/20180819144937_add_editor_to_users.rb
+++ b/db/migrate/20180819144937_add_editor_to_users.rb
@@ -1,0 +1,5 @@
+class AddEditorToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :editor, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_17_075318) do
+ActiveRecord::Schema.define(version: 2018_08_19_144937) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,6 +32,9 @@ ActiveRecord::Schema.define(version: 2018_08_17_075318) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "subscriber", default: false
+    t.boolean "author", default: false
+    t.boolean "editor", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/features/user_can_view_the_full_article.feature
+++ b/features/user_can_view_the_full_article.feature
@@ -18,4 +18,4 @@ Feature: User can view the full article
         Then I am on the "This is so sad" page
         And I should see "This is so sad"
         And I should see "A recent report suggest that news are mostly sad. Which is sad"
-        And I should see "2018-08-17"
+        And I should see "2018-08-19"

--- a/features/visitor_can_view_articles_landing_page.feature
+++ b/features/visitor_can_view_articles_landing_page.feature
@@ -12,7 +12,7 @@ Feature: Visitor can view articles on the landing page
         When I am on the 'landing' page
         Then I should see 'This is so sad'
         And I should see 'A recent report suggest that news are mostly sad. Which is sad.'
-        And I should see '2018-08-17'
+        And I should see '2018-08-19'
 
     
        

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe User, type: :model do
   describe "DB table" do
     it { is_expected.to have_db_column :email }
     it { is_expected.to have_db_column :encrypted_password }
+    it { is_expected.to have_db_column :subscriber }
+    it { is_expected.to have_db_column :author }
+    it { is_expected.to have_db_column :editor }
   end
 
 


### PR DESCRIPTION
### PT link
https://www.pivotaltracker.com/story/show/159732583

### User story
```
As a system owner,
In order to differentiate between the Users,
I would like to be able to apply different roles to Users.
```
### Other
We need to have discussion about if this simple boolean column added to a user solution is good enough. The user will have columns of subscriber, author and editor that can be set to true or false with `current_user.update_attribute :author, true`. And if it is sufficient to use `if current_user.author?` as a check. Otherwise we could use the `gem 'pundit'` or another simple Active Record enum.